### PR TITLE
fix typo

### DIFF
--- a/pages/sessions/cookies/index.md
+++ b/pages/sessions/cookies/index.md
@@ -108,7 +108,7 @@ function handleRequest(request: HTTPRequest, response: HTTPResponse): void {
 	// session validation
 	const cookies = parseCookieHeader(request.headers.get("Cookie") ?? "");
 	const token = cookies.get("session");
-	if (sessionId === null) {
+	if (token === null) {
 		response.setStatusCode(401);
 		return;
 	}


### PR DESCRIPTION
replace `sessionId` with `token` in session cookies